### PR TITLE
feat: add Vulkan ICD(Installable Client Drivers) support

### DIFF
--- a/debian/img-bxm-dkms.install
+++ b/debian/img-bxm-dkms.install
@@ -1,3 +1,4 @@
 #!/usr/bin/dh-exec
 
 src/modules/gpu/img-bxm usr/src/img-bxm-dkms-${DEB_VERSION}/
+img-bxm-dkms/usr/share usr/

--- a/img-bxm-dkms/usr/share/vulkan/icd.d/img_icd.json
+++ b/img-bxm-dkms/usr/share/vulkan/icd.d/img_icd.json
@@ -1,0 +1,7 @@
+{
+    "file_format_version": "1.0.0",
+    "ICD": {
+        "library_path": "libVK_IMG.so",
+        "api_version": "1.3.277"
+    }
+}


### PR DESCRIPTION
To support most Vulkan programs that use the Vulkan loader to load the driver